### PR TITLE
fix infinite read call at shutdown

### DIFF
--- a/crates/novasdr-server/src/input/soapysdr.rs
+++ b/crates/novasdr-server/src/input/soapysdr.rs
@@ -227,10 +227,7 @@ impl<T: soapysdr::StreamSample + Copy + Default> SoapyRead<T> {
             if self.stop_requested.load(Ordering::Relaxed)
                 || crate::shutdown::is_shutdown_requested()
             {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Interrupted,
-                    "shutdown",
-                ));
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, "shutdown"));
             }
             let mut bufs = [self.buf.as_mut_slice()];
             // Long timeout (1 second) to avoid busy-spinning; SoapySDR returns early when data arrives.


### PR DESCRIPTION
The problem: soapy driver never stopped properly at Ctrl+C. 
Root cause: flag ErrorKind::Interrupted tells io to call method read() again and again. ErrorKind::Other fixes this. At now soapy driver stops gracefully.
