### PR TITLE
Slightly restructure `compile.sh` file

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,13 +1,19 @@
-git pull
+#!/bin/bash
+set -e
 
+# Make sure we are inside of the source directory
+cd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Pull and get frontend submodule
+git pull
+git submodule update --init --recursive
+
+# Build the server
 cargo build -p novasdr-server --release --features "soapysdr,clfft"
 
+# Build the frontend
 cd frontend
-
 npm ci
-
-npm run build 
+npm run build
 
 cd ..
-
-exit


### PR DESCRIPTION
This PR is primarily based around three lines added, `set -e` to stop execution when a command fails, a `cd` command to enter the directory if the script is ran from outside of the source directory and a `git` command to pull in the submodules which allows the frontend part of the compile script to execute successfully, other than that a few comments were added to differentiate between each segments.

Also I saw that there was a `develop` branch but it's all initial commits so I didn't checkout to that branch for this PR.
