### PR TITLE
do not show disabled receivers in frontend

### DIFF
--- a/crates/novasdr-server/src/state.rs
+++ b/crates/novasdr-server/src/state.rs
@@ -554,6 +554,7 @@ pub async fn receivers_info(State(state): State<Arc<AppState>>) -> impl IntoResp
     let receivers = cfg
         .receivers
         .iter()
+        .filter(|r| r.enabled)
         .map(|r| {
             let rt = state
                 .receiver_state(r.id.as_str())


### PR DESCRIPTION
This is missed commit for my [previous PR](https://github.com/Steven9101/NovaSDR/pull/15). Disabled receivers should also be hidden in the web interface.