### PR TITLE
Update Docker workflows and submodule configurations

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3 # Necessário para emular ARM64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,12 +2,17 @@ name: Docker Publish
 
 on:
   push:
-    tags: [ 'v*.*.*' ] # Dispara quando você cria uma tag de versão (ex: v1.0.0)
-  workflow_dispatch:   # Permite rodar manualmente pela aba "Actions"
+    branches:
+      - main
+    tags:
+      - "v*"
+      - "[0-9]*.[0-9]*.[0-9]*"
+      - "[0-9]*.[0-9]*.[0-9]*-*"
+  workflow_dispatch:
 
 permissions:
   contents: read
-  packages: write # Essencial para publicar no GHCR
+  packages: write
 
 jobs:
   build-and-push:
@@ -19,10 +24,10 @@ jobs:
           submodules: recursive
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3 # Necessário para emular ARM64
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3 # Habilita recursos avançados de build
+        uses: docker/setup-buildx-action@v3
 
       - name: Log into registry ghcr.io
         uses: docker/login-action@v3
@@ -36,14 +41,20 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+          # Configuração Padrão Ouro para tagueamento múltiplo
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64 # Gera imagem para PC e Raspberry Pi
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha # Usa o cache do GitHub Actions para acelerar builds
+          cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Docker Publish
+
+on:
+  push:
+    tags: [ 'v*.*.*' ] # Dispara quando você cria uma tag de versão (ex: v1.0.0)
+  workflow_dispatch:   # Permite rodar manualmente pela aba "Actions"
+
+permissions:
+  contents: read
+  packages: write # Essencial para publicar no GHCR
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3 # Necessário para emular ARM64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3 # Habilita recursos avançados de build
+
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64 # Gera imagem para PC e Raspberry Pi
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha # Usa o cache do GitHub Actions para acelerar builds
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,10 +41,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
-          # Configuração Padrão Ouro para tagueamento múltiplo
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=ref,event=tag
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 
 [submodule "frontend"]
 	path = frontend
-	url = https://github.com/Steven9101/frontend
+	url = https://github.com/xnetinho/NovaSDR-frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,36 @@
-# ==========================================
-# ESTÁGIO 1: Frontend (Node.js)
-# ==========================================
+# ESTÁGIO 1: Frontend
 FROM node:20-slim AS frontend-builder
 WORKDIR /build
 COPY frontend/package*.json ./
-RUN npm ci
+# Ajuste para resiliência de submódulo
+RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 COPY frontend/ ./
 RUN npm run build
 
-# ==========================================
-# ESTÁGIO 2: Planejamento de Receita (Rust)
-# ==========================================
+# ESTÁGIO 2: Planejamento
 FROM rustlang/rust:nightly-bookworm-slim AS planner
-WORKDIR /app
+WORKDIR /build
 RUN cargo install cargo-chef
 COPY . .
-# Gera um arquivo de "receita" com as dependências
 RUN cargo chef prepare --recipe-path recipe.json
 
-# ==========================================
-# ESTÁGIO 3: Compilação de Dependências e Ferramentas C++
-# ==========================================
+# ESTÁGIO 3: Backend Builder
 FROM rustlang/rust:nightly-bookworm-slim AS backend-builder
-WORKDIR /app
+WORKDIR /build
 
-# Instalação de dependências do sistema
+# Instalação unificada de todas as dependências de build detectadas
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake pkg-config clang libclang-dev swig \
     python3 python3-dev python3-numpy ocl-icd-opencl-dev \
     libclfft-dev libusb-1.0-0-dev git ca-certificates \
-    rtl-sdr librtlsdr-dev \
+    rtl-sdr librtlsdr-dev libopus-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Instala o cargo-chef para cozinhar as dependências
 RUN cargo install cargo-chef
-COPY --from=planner /app/recipe.json recipe.json
-
-# "Cozinha" as dependências (Camada de Cache pesada)
+COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
-# Compila SoapySDR e drivers (Não mudam com frequência)
+# Compilação de Drivers (Padrão Ouro: explicitando diretórios de build)
 RUN git clone https://github.com/pothosware/SoapySDR.git /tmp/SoapySDR && \
     cmake -S /tmp/SoapySDR -B /tmp/SoapySDR/build -DCMAKE_BUILD_TYPE=Release && \
     make -C /tmp/SoapySDR/build -j$(nproc) install && \
@@ -48,37 +39,35 @@ RUN git clone https://github.com/pothosware/SoapySDR.git /tmp/SoapySDR && \
     make -C /tmp/SoapyRTLSDR/build -j$(nproc) install && \
     ldconfig && rm -rf /tmp/Soapy*
 
-# Agora sim, copia o código real e compila os binários
 COPY . .
 RUN cargo build --release --features "soapysdr,clfft" -p novasdr-server && \
     cargo build --release -p ws_probe
 
-# ==========================================
-# ESTÁGIO 4: Imagem de Runtime Final
-# ==========================================
+# ESTÁGIO 4: Runtime Final
 FROM debian:bookworm-slim
 WORKDIR /app
 
-# Dependências mínimas de execução
+# Adicionado libopus0 e garantido paridade de pacotes
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-1.0-0 ocl-icd-libopencl1 libclfft2 rtl-sdr \
     python3 python3-numpy ca-certificates netcat-openbsd \
+    libopus0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copia bibliotecas compiladas do SoapySDR
+# Cópia completa de bibliotecas e INCLUDES (conforme original)
 COPY --from=backend-builder /usr/local/lib/libSoapySDR* /usr/local/lib/
 COPY --from=backend-builder /usr/local/lib/SoapySDR /usr/local/lib/SoapySDR
+COPY --from=backend-builder /usr/local/include/SoapySDR /usr/local/include/SoapySDR
 COPY --from=backend-builder /usr/local/bin/SoapySDRUtil /usr/local/bin/
 RUN ldconfig
 
-# Copia Binários, Frontend, Configs e Recursos
-COPY --from=backend-builder /app/target/release/novasdr-server /app/
-COPY --from=backend-builder /app/target/release/ws_probe /app/
+# Binários e Recursos (Caminhos de origem corrigidos para /build)
+COPY --from=backend-builder /build/target/release/novasdr-server /app/
+COPY --from=backend-builder /build/target/release/ws_probe /app/
 COPY --from=frontend-builder /build/dist /app/frontend/dist
 COPY config/ /app/config/
 COPY crates/novasdr-server/resources/ /app/resources/
 
-# Preparação de diretórios e ambiente
 RUN mkdir -p /app/logs /app/data
 EXPOSE 9002
 ENV RUST_LOG=info RUST_BACKTRACE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,127 +1,86 @@
-# Multi-stage Dockerfile for NovaSDR
-# Builds frontend, Rust backend with SoapySDR and OpenCL support
-
-# Stage 1: Build the frontend
+# ==========================================
+# ESTÁGIO 1: Frontend (Node.js)
+# ==========================================
 FROM node:20-slim AS frontend-builder
-
 WORKDIR /build
-
-# Copy frontend package files
 COPY frontend/package*.json ./
-
-# Install dependencies
 RUN npm ci
-
-# Copy frontend source
 COPY frontend/ ./
-
-# Build the frontend
 RUN npm run build
 
-# Stage 2: Build the Rust backend
+# ==========================================
+# ESTÁGIO 2: Planejamento de Receita (Rust)
+# ==========================================
+FROM rustlang/rust:nightly-bookworm-slim AS planner
+WORKDIR /app
+RUN cargo install cargo-chef
+COPY . .
+# Gera um arquivo de "receita" com as dependências
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ==========================================
+# ESTÁGIO 3: Compilação de Dependências e Ferramentas C++
+# ==========================================
 FROM rustlang/rust:nightly-bookworm-slim AS backend-builder
-
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    cmake \
-    pkg-config \
-    clang \
-    libclang-dev \
-    swig \
-    python3 \
-    python3-dev \
-    python3-numpy \
-    ocl-icd-opencl-dev \
-    libclfft-dev \
-    libusb-1.0-0-dev \
-    git \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-
-# Copy Cargo workspace files
-COPY Cargo.toml ./
-COPY crates/ ./crates/
-
-# Build SoapySDR from source (for better compatibility)
-RUN git clone https://github.com/pothosware/SoapySDR.git /tmp/SoapySDR && \
-    cd /tmp/SoapySDR && \
-    mkdir build && cd build && \
-    cmake .. && \
-    make -j$(nproc) && \
-    make install && \
-    ldconfig && \
-    rm -rf /tmp/SoapySDR
-
-# Build SoapyRTLSDR (RTL-SDR support)
-RUN apt-get update && apt-get install -y --no-install-recommends rtl-sdr librtlsdr-dev && \
-    git clone https://github.com/pothosware/SoapyRTLSDR.git /tmp/SoapyRTLSDR && \
-    cd /tmp/SoapyRTLSDR && \
-    mkdir build && cd build && \
-    cmake .. && \
-    make -j$(nproc) && \
-    make install && \
-    rm -rf /tmp/SoapyRTLSDR && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Build the Rust backend with SoapySDR and clFFT support
-RUN cargo build --release --features "soapysdr,clfft" -p novasdr-server
-
-# Build the ws_probe utility
-RUN cargo build --release -p ws_probe
-
-# Stage 3: Final runtime image
-FROM debian:bookworm-slim
-
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libusb-1.0-0 \
-    ocl-icd-libopencl1 \
-    libclfft2 \
-    rtl-sdr \
-    python3 \
-    python3-numpy \
-    ca-certificates \
-    netcat-openbsd \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy SoapySDR runtime from builder
-COPY --from=backend-builder /usr/local/lib/libSoapySDR* /usr/local/lib/
-COPY --from=backend-builder /usr/local/lib/SoapySDR /usr/local/lib/SoapySDR
-COPY --from=backend-builder /usr/local/include/SoapySDR /usr/local/include/SoapySDR
-COPY --from=backend-builder /usr/local/bin/SoapySDRUtil /usr/local/bin/
-
-# Update library cache
-RUN ldconfig
-
-# Create application directory
 WORKDIR /app
 
-# Copy built binaries from backend builder
-COPY --from=backend-builder /build/target/release/novasdr-server /app/
-COPY --from=backend-builder /build/target/release/ws_probe /app/
+# Instalação de dependências do sistema
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake pkg-config clang libclang-dev swig \
+    python3 python3-dev python3-numpy ocl-icd-opencl-dev \
+    libclfft-dev libusb-1.0-0-dev git ca-certificates \
+    rtl-sdr librtlsdr-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-# Copy built frontend from frontend builder
+# Instala o cargo-chef para cozinhar as dependências
+RUN cargo install cargo-chef
+COPY --from=planner /app/recipe.json recipe.json
+
+# "Cozinha" as dependências (Camada de Cache pesada)
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Compila SoapySDR e drivers (Não mudam com frequência)
+RUN git clone https://github.com/pothosware/SoapySDR.git /tmp/SoapySDR && \
+    cmake -S /tmp/SoapySDR -B /tmp/SoapySDR/build -DCMAKE_BUILD_TYPE=Release && \
+    make -C /tmp/SoapySDR/build -j$(nproc) install && \
+    git clone https://github.com/pothosware/SoapyRTLSDR.git /tmp/SoapyRTLSDR && \
+    cmake -S /tmp/SoapyRTLSDR -B /tmp/SoapyRTLSDR/build -DCMAKE_BUILD_TYPE=Release && \
+    make -C /tmp/SoapyRTLSDR/build -j$(nproc) install && \
+    ldconfig && rm -rf /tmp/Soapy*
+
+# Agora sim, copia o código real e compila os binários
+COPY . .
+RUN cargo build --release --features "soapysdr,clfft" -p novasdr-server && \
+    cargo build --release -p ws_probe
+
+# ==========================================
+# ESTÁGIO 4: Imagem de Runtime Final
+# ==========================================
+FROM debian:bookworm-slim
+WORKDIR /app
+
+# Dependências mínimas de execução
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libusb-1.0-0 ocl-icd-libopencl1 libclfft2 rtl-sdr \
+    python3 python3-numpy ca-certificates netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copia bibliotecas compiladas do SoapySDR
+COPY --from=backend-builder /usr/local/lib/libSoapySDR* /usr/local/lib/
+COPY --from=backend-builder /usr/local/lib/SoapySDR /usr/local/lib/SoapySDR
+COPY --from=backend-builder /usr/local/bin/SoapySDRUtil /usr/local/bin/
+RUN ldconfig
+
+# Copia Binários, Frontend, Configs e Recursos
+COPY --from=backend-builder /app/target/release/novasdr-server /app/
+COPY --from=backend-builder /app/target/release/ws_probe /app/
 COPY --from=frontend-builder /build/dist /app/frontend/dist
-
-# Copy configuration files
 COPY config/ /app/config/
-
-# Copy resources (default bands, etc.)
 COPY crates/novasdr-server/resources/ /app/resources/
 
-# Create directories for runtime data
+# Preparação de diretórios e ambiente
 RUN mkdir -p /app/logs /app/data
-
-# Expose the default port
 EXPOSE 9002
+ENV RUST_LOG=info RUST_BACKTRACE=1
 
-# Set environment variables
-ENV RUST_LOG=info
-ENV RUST_BACKTRACE=1
-
-# Run the server
 CMD ["/app/novasdr-server", "-c", "/app/config/config.json", "-r", "/app/config/receivers.json"]


### PR DESCRIPTION
This pull request introduces significant improvements to the Docker build and deployment workflow for the project. The changes include a new GitHub Actions workflow for automated Docker publishing, updates to the frontend submodule URL, and a comprehensive refactor of the `Dockerfile` to optimize build stages, increase resilience, and enhance compatibility.

**CI/CD Improvements:**

* Added a new `.github/workflows/docker-publish.yml` workflow to automate building and publishing Docker images on pushes to `main` and tags, supporting multi-platform builds and caching for faster builds.

**Submodule Management:**

* Updated the frontend submodule URL in `.gitmodules` to point to `xnetinho/NovaSDR-frontend` for improved source management and reliability.

**Dockerfile Refactor and Build Optimization:**

* Refactored the `Dockerfile` with explicit multi-stage builds, including a frontend builder, Rust planner for dependency caching, backend builder, and final runtime image, improving build speed and reliability.
* Enhanced resilience for frontend builds by conditionally running `npm ci` or `npm install` based on the presence of `package-lock.json`.
* Unified and expanded build dependencies, added explicit driver builds for SoapySDR and RTL-SDR, and ensured runtime parity with additional libraries like `libopus0`.
* Corrected paths for copying binaries and resources, and streamlined environment variable setup and runtime commands in the final image.